### PR TITLE
[expo-quest-notifications] feat: use `APP_ID` from `BuildConfig`

### DIFF
--- a/expo-quest-notifications/android/build.gradle
+++ b/expo-quest-notifications/android/build.gradle
@@ -11,12 +11,15 @@ expoModule {
   canBePublished false
 }
 
+def questAppIdConfigField = "\"${project.findProperty('questAppId') ?: ''}\""
+
 android {
   namespace "expo.modules.notifications"
   defaultConfig {
     versionCode 21
     versionName '0.32.11'
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    buildConfigField "String", "META_QUEST_APP_ID", questAppIdConfigField
   }
 
   buildFeatures {

--- a/expo-quest-notifications/android/src/quest/java/expo/modules/notifications/tokens/PushTokenModule.kt
+++ b/expo-quest-notifications/android/src/quest/java/expo/modules/notifications/tokens/PushTokenModule.kt
@@ -6,6 +6,7 @@ import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
+import expo.modules.notifications.BuildConfig
 import expo.modules.notifications.service.delegates.FirebaseMessagingDelegate.Companion.addTokenListener
 import expo.modules.notifications.tokens.interfaces.FirebaseTokenListener
 
@@ -16,7 +17,7 @@ private const val UNREGISTER_FOR_NOTIFICATIONS_FAIL_CODE = "E_UNREGISTER_FOR_NOT
 
 class PushTokenModule : Module(), FirebaseTokenListener {
   private companion object {
-    private const val APP_ID = "31229554193356425"
+    private const val APP_ID = BuildConfig.META_QUEST_APP_ID
   }
 
   /**


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
This PR updates the project to use the `APP_ID` configured in the `expo-quest` common plugin from the build configuration.

## Testing

<!-- Describe the tests you've performed to verify your changes -->

Performed a clean prebuild, ran the app, and verified that the new `APP_ID` value is correctly applied in the `expo-quest-notifications`.