### PR TITLE
[expo-quest] feat: add `allowBackup` option

### DIFF
--- a/example/app.config.ts
+++ b/example/app.config.ts
@@ -47,7 +47,8 @@ module.exports = () => ({
                 "defaultHeight": "640dp",
                 "defaultWidth": "1024dp",
                 "supportedDevices": "quest2|quest3|quest3s",
-                "disableVrHeadtracking": false
+                "disableVrHeadtracking": false,
+                "allowBackup": false
             }
         ],
         "expo-task-manager",

--- a/expo-quest/README.md
+++ b/expo-quest/README.md
@@ -90,7 +90,7 @@ Add the plugin to your `app.json` or `app.config.[js|ts]`:
           "defaultWidth": "1024dp",
           "supportedDevices": "quest2|quest3|quest3s",
           "disableVrHeadtracking": false,
-          "allowBackup": true
+          "allowBackup": false
         }
       ]
     ]
@@ -100,14 +100,14 @@ Add the plugin to your `app.json` or `app.config.[js|ts]`:
 
 #### Available Options
 
-| Option                  | Type      | Required | Default   | Description                                                                                                                                                                                           |
-| ----------------------- | --------- | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `questAppId`            | `string`  | No       | `""`      | Your Meta Quest application ID. Required for publishing to the Meta Quest Store.                                                                                                                      |
-| `defaultHeight`         | `string`  | No       | Not added | Default panel height in dp (e.g., `"640dp"`). See [Panel Sizing](https://developers.meta.com/horizon/documentation/android-apps/panel-sizing)                                                         |
-| `defaultWidth`          | `string`  | No       | Not added | Default panel width in dp (e.g., `"1024dp"`). See [Panel Sizing](https://developers.meta.com/horizon/documentation/android-apps/panel-sizing)                                                         |
-| `supportedDevices`      | `string`  | Yes      | None      | Pipe-separated list of supported Quest devices: `"quest2\|quest3\|quest3s"`. See [Mobile Manifest](https://developers.meta.com/horizon/resources/publish-mobile-manifest/)                            |
-| `disableVrHeadtracking` | `boolean` | No       | `false`   | Set to `true` to disable VR headtracking feature. By default, adds `android.hardware.vr.headtracking` to AndroidManifest.                                                                             |
-| `allowBackup`           | `boolean` | No       | `true`    | Set to `false` in the Quest build to disable Android's `allowBackup` feature, which removes the "allowBackup=true" warning in the Meta Horizon Store. This does not affect your mobile build variant. |
+| Option                  | Type      | Required | Default   | Description                                                                                                                                                                                                                      |
+| ----------------------- | --------- | -------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `questAppId`            | `string`  | No       | `""`      | Your Meta Quest application ID. Required for publishing to the Meta Quest Store.                                                                                                                                                 |
+| `defaultHeight`         | `string`  | No       | Not added | Default panel height in dp (e.g., `"640dp"`). See [Panel Sizing](https://developers.meta.com/horizon/documentation/android-apps/panel-sizing)                                                                                    |
+| `defaultWidth`          | `string`  | No       | Not added | Default panel width in dp (e.g., `"1024dp"`). See [Panel Sizing](https://developers.meta.com/horizon/documentation/android-apps/panel-sizing)                                                                                    |
+| `supportedDevices`      | `string`  | Yes      | None      | Pipe-separated list of supported Quest devices: `"quest2\|quest3\|quest3s"`. See [Mobile Manifest](https://developers.meta.com/horizon/resources/publish-mobile-manifest/)                                                       |
+| `disableVrHeadtracking` | `boolean` | No       | `false`   | Set to `true` to disable VR headtracking feature. By default, adds `android.hardware.vr.headtracking` to AndroidManifest.                                                                                                        |
+| `allowBackup`           | `boolean` | No       | `false`   | Set to `true` in the Quest build to enable Android's `allowBackup` feature. The default value is `false` which removes the "allowBackup=true" warning in the Meta Horizon Store. This does not affect your mobile build variant. |
 
 
 > **Meta Horizon Store Recommendation for `allowBackup`:**

--- a/expo-quest/README.md
+++ b/expo-quest/README.md
@@ -89,7 +89,8 @@ Add the plugin to your `app.json` or `app.config.[js|ts]`:
           "defaultHeight": "640dp",
           "defaultWidth": "1024dp",
           "supportedDevices": "quest2|quest3|quest3s",
-          "disableVrHeadtracking": false
+          "disableVrHeadtracking": false,
+          "allowBackup": true
         }
       ]
     ]
@@ -99,13 +100,20 @@ Add the plugin to your `app.json` or `app.config.[js|ts]`:
 
 #### Available Options
 
-| Option                  | Type      | Required | Default   | Description                                                                                                                                                                |
-| ----------------------- | --------- | -------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `questAppId`            | `string`  | No       | `""`      | Your Meta Quest application ID. Required for publishing to the Meta Quest Store.                                                                                           |
-| `defaultHeight`         | `string`  | No       | Not added | Default panel height in dp (e.g., `"640dp"`). See [Panel Sizing](https://developers.meta.com/horizon/documentation/android-apps/panel-sizing)                              |
-| `defaultWidth`          | `string`  | No       | Not added | Default panel width in dp (e.g., `"1024dp"`). See [Panel Sizing](https://developers.meta.com/horizon/documentation/android-apps/panel-sizing)                              |
-| `supportedDevices`      | `string`  | Yes      | None      | Pipe-separated list of supported Quest devices: `"quest2\|quest3\|quest3s"`. See [Mobile Manifest](https://developers.meta.com/horizon/resources/publish-mobile-manifest/) |
-| `disableVrHeadtracking` | `boolean` | No       | `false`   | Set to `true` to disable VR headtracking feature. By default, adds `android.hardware.vr.headtracking` to AndroidManifest.                                                  |
+| Option                  | Type      | Required | Default   | Description                                                                                                                                                                                           |
+| ----------------------- | --------- | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `questAppId`            | `string`  | No       | `""`      | Your Meta Quest application ID. Required for publishing to the Meta Quest Store.                                                                                                                      |
+| `defaultHeight`         | `string`  | No       | Not added | Default panel height in dp (e.g., `"640dp"`). See [Panel Sizing](https://developers.meta.com/horizon/documentation/android-apps/panel-sizing)                                                         |
+| `defaultWidth`          | `string`  | No       | Not added | Default panel width in dp (e.g., `"1024dp"`). See [Panel Sizing](https://developers.meta.com/horizon/documentation/android-apps/panel-sizing)                                                         |
+| `supportedDevices`      | `string`  | Yes      | None      | Pipe-separated list of supported Quest devices: `"quest2\|quest3\|quest3s"`. See [Mobile Manifest](https://developers.meta.com/horizon/resources/publish-mobile-manifest/)                            |
+| `disableVrHeadtracking` | `boolean` | No       | `false`   | Set to `true` to disable VR headtracking feature. By default, adds `android.hardware.vr.headtracking` to AndroidManifest.                                                                             |
+| `allowBackup`           | `boolean` | No       | `true`    | Set to `false` in the Quest build to disable Android's `allowBackup` feature, which removes the "allowBackup=true" warning in the Meta Horizon Store. This does not affect your mobile build variant. |
+
+
+> **Meta Horizon Store Recommendation for `allowBackup`:**
+>
+> If the application is storing sensitive information on the device, it is recommended to disable backups by setting `allowBackup="false"` in your application's AndroidManifest.
+>
 
 ### Configuration Examples
 

--- a/expo-quest/plugin/src/withCustomAndroidManifest.ts
+++ b/expo-quest/plugin/src/withCustomAndroidManifest.ts
@@ -14,6 +14,7 @@ type QuestManifestOptions = {
   defaultWidth?: string;
   supportedDevices?: string;
   disableVrHeadtracking?: boolean;
+  allowBackup?: boolean;
 };
 
 /**
@@ -180,7 +181,13 @@ function createQuestManifest(
 
   // Create application node with only Quest-specific additions
   const application: any = {
-    $: {},
+    $: {
+      // Default to false for Quest (disabled by default for security, recommended by Meta)
+      // User can enable with allowBackup: true option
+      "android:allowBackup": String(options.allowBackup ?? false),
+      // Tell the manifest merger to replace the `allowBackup` value from main manifest
+      "tools:replace": "android:allowBackup",
+    },
     "meta-data": [],
     activity: [],
   };
@@ -217,10 +224,7 @@ function createQuestManifest(
     });
   }
 
-  // Only add application if it has content
-  if (application["meta-data"].length > 0 || application.activity.length > 0) {
-    manifest.manifest.application!.push(application);
-  }
+  manifest.manifest.application!.push(application);
 
   return manifest;
 }

--- a/expo-quest/plugin/src/withCustomAndroidManifest.ts
+++ b/expo-quest/plugin/src/withCustomAndroidManifest.ts
@@ -182,9 +182,9 @@ function createQuestManifest(
   // Create application node with only Quest-specific additions
   const application: any = {
     $: {
-      // Default to true for Quest (disabled by default for security, recommended by Meta)
+      // Default to false for Quest (disabled by default for security, recommended by Meta)
       // User can enable with allowBackup: true option
-      "android:allowBackup": String(options.allowBackup ?? true),
+      "android:allowBackup": String(options.allowBackup ?? false),
       // Tell the manifest merger to replace the `allowBackup` value from main manifest
       "tools:replace": "android:allowBackup",
     },

--- a/expo-quest/plugin/src/withCustomAndroidManifest.ts
+++ b/expo-quest/plugin/src/withCustomAndroidManifest.ts
@@ -182,9 +182,9 @@ function createQuestManifest(
   // Create application node with only Quest-specific additions
   const application: any = {
     $: {
-      // Default to false for Quest (disabled by default for security, recommended by Meta)
+      // Default to true for Quest (disabled by default for security, recommended by Meta)
       // User can enable with allowBackup: true option
-      "android:allowBackup": String(options.allowBackup ?? false),
+      "android:allowBackup": String(options.allowBackup ?? true),
       // Tell the manifest merger to replace the `allowBackup` value from main manifest
       "tools:replace": "android:allowBackup",
     },

--- a/expo-quest/plugin/src/withQuest.ts
+++ b/expo-quest/plugin/src/withQuest.ts
@@ -12,6 +12,7 @@ type HorizonOptions = {
   defaultWidth?: string;
   supportedDevices?: string;
   disableVrHeadtracking?: boolean;
+  allowBackup?: boolean;
 };
 
 const USE_EXPERIMENTAL_PLUGIN = true;


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

Added configurable `allowBackup` option for Quest builds that defaults to false to comply with Meta Horizon Store security requirements.

Official Meta Horizon store flags apps with `allowBackup="true"` as a security vulnerability, warning that it "allows anyone who has access to the device to obtain a copy of the application's private data":

<details><summary>Meta Horizon Store feedback</summary>
<p>

Application allows backup of private data
Summary
This security vulnerability is important, consider fixing it.
Location of Vulnerable Code in Your Build
AndroidManifest.xml::<application android:allowBackup="true">
Description
The allowBackup setting is not explicitly configured to False within the application's Android Manifest.

If [android:allowBackup](https://developer.android.com/guide/topics/manifest/application-element#allowbackup) attribute is explicitly set to True or not explicitly set, it allows anyone who has access to the device to obtain a copy of the application's private data.
Recommendation
If the application is storing sensitive information on the device, it is recommended to disable backups by setting allowBackup="False" in the application's Android Manifest.

</p>
</details> 

## Testing

<!-- Describe the tests you've performed to verify your changes -->
1. Run prebuild with `allowBackup` set to `false`.
2. Verify the Meta Horizon Store doesn't show a warning regarding it.

