### PR TITLE
ci: add dummy publish-core workflow to register dispatch

### DIFF
--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -1,0 +1,15 @@
+name: Publish expo-horizon-core to NPM
+on:
+  workflow_dispatch:
+    inputs:
+      release-type:
+        type: choice
+        options: [stable, nightly, rc]
+      dry-run:
+        type: boolean
+        default: true
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Workflow registered on main!"

--- a/.github/workflows/publish-location.yml
+++ b/.github/workflows/publish-location.yml
@@ -1,0 +1,15 @@
+name: Publish expo-horizon-location to NPM
+on:
+  workflow_dispatch:
+    inputs:
+      release-type:
+        type: choice
+        options: [stable, nightly, rc]
+      dry-run:
+        type: boolean
+        default: true
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Workflow registered on main!"

--- a/.github/workflows/publish-notifications.yml
+++ b/.github/workflows/publish-notifications.yml
@@ -1,0 +1,15 @@
+name: Publish expo-horizon-notifications to NPM
+on:
+  workflow_dispatch:
+    inputs:
+      release-type:
+        type: choice
+        options: [stable, nightly, rc]
+      dry-run:
+        type: boolean
+        default: true
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Workflow registered on main!"


### PR DESCRIPTION
## Description

This PR adds a stubbed version of the `publish-*.yml` GitHub Actions workflow. 

**Why?**
GitHub's UI will not show the "Run workflow" button for a `workflow_dispatch` action unless the file already exists on the default branch (`main`). 

This stub safely registers the workflow in the UI without executing any actual publishing logic. Once this is merged, I can run the workflow from my feature branch to safely test the `software-mansion/npm-package-publish` action using a dry run.