### PR TITLE
refactor(example): split app manifest into static and dynamic for Expo tooling

### DIFF
--- a/example/app.config.ts
+++ b/example/app.config.ts
@@ -1,64 +1,36 @@
-export default () => ({
-  expo: {
-    name: 'expo-horizon-demo',
-    slug: 'expo-horizon-demo',
-    version: '1.0.0',
-    orientation: 'default',
-    icon: './assets/icon.png',
-    userInterfaceStyle: 'light',
-    newArchEnabled: true,
-    splash: {
-      image: './assets/splash-icon.png',
-      resizeMode: 'contain',
-      backgroundColor: '#ffffff',
-    },
-    ios: {
-      supportsTablet: true,
-      bundleIdentifier: 'com.anonymous.app',
-    },
-    android: {
-      versionCode: 4,
-      adaptiveIcon: {
-        foregroundImage: './assets/adaptive-icon.png',
-        backgroundColor: '#ffffff',
+import type { ConfigContext, ExpoConfig } from 'expo/config';
+
+export default ({ config }: ConfigContext): ExpoConfig => ({
+  ...config,
+  name: config.name!,
+  slug: config.slug!,
+  plugins: [
+    ...(config.plugins ?? []),
+    [
+      '../expo-horizon-location/app.plugin.js',
+      {
+        isAndroidBackgroundLocationEnabled: true,
+        isAndroidForegroundServiceEnabled: true,
+        // isAndroidMotionActivityEnabled omitted: ACTIVITY_RECOGNITION is prohibited on the Horizon Store.
+        isAndroidMotionActivityEnabled: true,
+        locationAlwaysAndWhenInUsePermission:
+          'Allow $(PRODUCT_NAME) to access your location for background tracking',
+        locationAlwaysPermission:
+          'Allow $(PRODUCT_NAME) to access your location for background tracking',
+        locationWhenInUsePermission: 'Allow $(PRODUCT_NAME) to access your location',
       },
-      edgeToEdgeEnabled: true,
-      package: 'com.swmansion.horizon.demo',
-    },
-    web: {
-      favicon: './assets/favicon.png',
-    },
-    plugins: [
-      'expo-build-properties',
-      ['expo-router'],
-      [
-        '../expo-horizon-location/app.plugin.js',
-        {
-          isAndroidBackgroundLocationEnabled: true,
-          isAndroidForegroundServiceEnabled: true,
-          // isAndroidMotionActivityEnabled omitted: ACTIVITY_RECOGNITION is prohibited on the Horizon Store.
-          isAndroidMotionActivityEnabled: true,
-          locationAlwaysAndWhenInUsePermission:
-            'Allow $(PRODUCT_NAME) to access your location for background tracking',
-          locationAlwaysPermission:
-            'Allow $(PRODUCT_NAME) to access your location for background tracking',
-          locationWhenInUsePermission: 'Allow $(PRODUCT_NAME) to access your location',
-        },
-      ],
-      '../expo-horizon-notifications/app.plugin.js',
-      [
-        '../expo-horizon-core/app.plugin.js',
-        {
-          horizonAppId: 'DEMO_APP_ID',
-          defaultHeight: '640dp',
-          defaultWidth: '1024dp',
-          supportedDevices: 'quest2|quest3|quest3s',
-          disableVrHeadtracking: false,
-          allowBackup: false,
-        },
-      ],
-      'expo-task-manager',
-      'expo-status-bar',
     ],
-  },
+    '../expo-horizon-notifications/app.plugin.js',
+    [
+      '../expo-horizon-core/app.plugin.js',
+      {
+        horizonAppId: 'DEMO_APP_ID',
+        defaultHeight: '640dp',
+        defaultWidth: '1024dp',
+        supportedDevices: 'quest2|quest3|quest3s',
+        disableVrHeadtracking: false,
+        allowBackup: false,
+      },
+    ],
+  ],
 });

--- a/example/app.json
+++ b/example/app.json
@@ -1,0 +1,36 @@
+{
+  "name": "expo-horizon-demo",
+  "slug": "expo-horizon-demo",
+  "version": "1.0.0",
+  "orientation": "default",
+  "icon": "./assets/icon.png",
+  "userInterfaceStyle": "light",
+  "newArchEnabled": true,
+  "splash": {
+    "image": "./assets/splash-icon.png",
+    "resizeMode": "contain",
+    "backgroundColor": "#ffffff"
+  },
+  "ios": {
+    "supportsTablet": true,
+    "bundleIdentifier": "com.anonymous.app"
+  },
+  "android": {
+    "versionCode": 4,
+    "adaptiveIcon": {
+      "foregroundImage": "./assets/adaptive-icon.png",
+      "backgroundColor": "#ffffff"
+    },
+    "edgeToEdgeEnabled": true,
+    "package": "com.swmansion.horizon.demo"
+  },
+  "web": {
+    "favicon": "./assets/favicon.png"
+  },
+  "plugins": [
+    "expo-build-properties",
+    "expo-router",
+    "expo-task-manager",
+    "expo-status-bar"
+  ]
+}

--- a/example/app.json
+++ b/example/app.json
@@ -27,10 +27,5 @@
   "web": {
     "favicon": "./assets/favicon.png"
   },
-  "plugins": [
-    "expo-build-properties",
-    "expo-router",
-    "expo-task-manager",
-    "expo-status-bar"
-  ]
+  "plugins": ["expo-build-properties", "expo-router", "expo-task-manager", "expo-status-bar"]
 }


### PR DESCRIPTION
## Description

Some of the Expo commands or tooling tries to update the app manifest, e.g. when installing a library with a config plugin through `expo install <library>`. Splitting the app manifest into static and dynamic allows Expo to make these changes automatically.

- Added type annotations in **app.config.ts**
- Removed parent `{ expo: { ... } }` object
- Force-typed `name`/`slug` from `string | undefined` into `string`
  - _This is a typing issue on Expo's side, we will get it fixed. But for now, this works._

## Testing

The following commands should continue to work as expected.

- `yarn install`
- `cd example`
- `yarn install`
- `yarn expo config --json`
